### PR TITLE
TODO inicial para Lab 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ tiny_md
 viz
 *.o
 .depend
-
+*.log
+*.xyz

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,12 @@
+# TODO
+
+## Lab 1
+
+- Elegir una (o varias) métricas de performance del problema.
+- Crear tests sobre el output de tiny_md y automatizar su ejecución con un target en el Makefile.
+- Tomar el tamaño de la simulación (N - numero de particulas) como parámetros de entrada.
+- Crear un target en el Makefile para generar un archivo con información de performance para varios tamaños de simulación preestablecidos.
+- Crear un target en el Makefile que tome una lista de archivos de performance y genere un gráfico de performance con los mismos:
+    - Grafico "Performance vs. tamaño del problema"
+- Medir la performance inicial del programa.
+- Crear Releases por cada milestone alcanzado. Luego podremos comparar performance entre releases y ver como evoluciona el programa.


### PR DESCRIPTION
- Agregar archivos de salida a .gitignore (por el momento no nos interesan, pero si van a importar cuando empecemos a medir la performance de distintas releases. Esos archivos de performance podrian quedar en `/performance` o similar
- TODO inicial para Lab 1